### PR TITLE
fix #10: fix image diplaying and opening problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.1.3] - 2021-02-02
+
+- Fix critical bug about displaying and opening image.
+
 ## [0.1.2] - 2020-05-27
 
 - Add compatible image formats.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "image-tile-viewer",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Image Tile Viewer",
 	"description": "extension for showing images in tile view.",
 	"icon": "media/icon.png",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"publisher": "ayatough",
 	"author": {
 		"name": "ayatough",


### PR DESCRIPTION
fixed bug below.

- image displaying is failed on window machine
- image opening is failed on every machine

## test

checked case on win and ubuntu and WSL.

## reference

https://stackoverflow.com/questions/8683895/how-do-i-determine-the-current-operating-system-with-node-js